### PR TITLE
fix: parse response asynchronously

### DIFF
--- a/src/proxy-durable.js
+++ b/src/proxy-durable.js
@@ -1,13 +1,13 @@
 import { json, StatusError } from 'itty-router-extras'
 
 // helper function to parse response
-const transformResponse = response => {
+const transformResponse = async response => {
   try {
-    return response.json()
+    return await response.json()
   } catch (err) {}
 
   try {
-    return response.text()
+    return await response.text()
   } catch (err) {}
 
   return response


### PR DESCRIPTION
From durable:
```javascript
const another = proxyDurable(ANOTHER_DURABLE).get('default', { class: AnotherDurable, parse: true });
const result = await another.method(); // Returns successfully but with console.error:

[mf:err] Unhandled Promise Rejection: SyntaxError: Unexpected end of JSON input
at JSON.parse (<anonymous>)
    at Response.json (/node_modules/undici/lib/fetch/body.js:306:17)
    at runNextTicks (node:internal/process/task_queues:61:5)
    at processImmediate (node:internal/timers:437:9)
    at process.topLevelDomainCallback (node:domain:152:15)
    at process.callbackTrampoline (node:internal/async_hooks:128:24)
```
Good work! Working with durable objects is now much easier!
