### PR TITLE
Allow a Durable Object to create new unique ids and get ids from a string

### DIFF
--- a/src/itty-durable.js
+++ b/src/itty-durable.js
@@ -22,6 +22,7 @@ export const createDurable = (options = {}) => {
         defaultState: undefined,
         initialized: false,
         router: Router(),
+        env,
         ...env,
         ...state,
       }


### PR DESCRIPTION
In a durable object, the proxies overwrite the stubs on state. This will allow a durable object to still be able to create new ids and convert id strings to id objects for use in Proxy.get(id).

```js
const stub = this.state.env.Counter;
const newId = stub.newUniqueId();
const idObj = stub.idFromString(storedObjectId);
this.state.Counter.get(newId).increment();
this.state.Counter.get(idObj).increment();
```

This is needed for creating fan-out systems or connection pooling like https://github.com/cloudflare/dog/.