### PR TITLE
Fix transformResponse

### DIFF
--- a/src/proxy-durable.js
+++ b/src/proxy-durable.js
@@ -1,13 +1,13 @@
 import { json, StatusError } from 'itty-router-extras'
 
 // helper function to parse response
-const transformResponse = response => {
+const transformResponse = async response => {
   try {
-    return response.json()
-  } catch (err) {}
-
-  try {
-    return response.text()
+    const text = await response.text()
+    try {
+      return JSON.parse(text)
+    } catch (err) {}
+    return text
   } catch (err) {}
 
   return response


### PR DESCRIPTION
The `transformResponse` fails for invalid JSON. Because it wasn't async, it would always return the promise from the response.json() call. Making it async allowed it to fail the JSON and move on to the next step, but because the body was already read/parsed, the response.text() would always fail. So we have to read the text first, then try and parse it as JSON. If it is JSON, return it. If not, return the text. If reading the text failed, return a response.