### PR TITLE
fix: actually fall back to text or raw response if no JSON is returned

### DIFF
--- a/src/proxy-durable.js
+++ b/src/proxy-durable.js
@@ -1,13 +1,13 @@
 import { json, StatusError } from 'itty-router-extras'
 
 // helper function to parse response
-const transformResponse = response => {
+const transformResponse = async (response) => {
   try {
-    return response.json()
+    return await response.json()
   } catch (err) {}
 
   try {
-    return response.text()
+    return await response.text()
   } catch (err) {}
 
   return response


### PR DESCRIPTION
I noticed that with `parse: true`, my DO methods that returned a non-JSON string caused JSON.parse errors. This was because the `catch` clauses never actually did anything, because the `transformResponse` method returned the Promise without handling errors.