### PR TITLE
Support `newUniqueId` and `idFromString`

### DIFF
--- a/src/proxy-durable.js
+++ b/src/proxy-durable.js
@@ -46,9 +46,16 @@ export const proxyDurable = (durable, middlewareOptions = {}) => {
       // const originalHeaders = Object.fromEntries(options.request.headers)
 
       try {
-        if (typeof id === 'string') { // should add check for hex id string and handle appropriately
-          headers['do-name'] = id
-          id = durable.idFromName(id)
+        if (!id) id = durable.newUniqueId()
+
+        if (typeof id === 'string') {
+          const existingId = /^[0-9a-fA-F]{64}$/
+          if (existingId.test(id)) {
+            id = durable.idFromString(id)
+          } else {
+            headers['do-name'] = id
+            id = durable.idFromName(id)
+          }
         }
 
         const stub = durable.get(id)


### PR DESCRIPTION
This solves #21 and #29.  If `get()` is called with an undefined `id` then it is generated with `newUniqueId`, and if an existing Cloudflare-generated 64-digit is passed in then `idFromString` is called instead of `durable.idFromName(id)`